### PR TITLE
Lock OmniAI to ~> 1.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-deepseek (0.1.1)
+    omniai-deepseek (1.9.0)
       event_stream_parser
-      omniai
+      omniai (~> 1.9)
       zeitwerk
 
 GEM

--- a/lib/omniai/deepseek/version.rb
+++ b/lib/omniai/deepseek/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module DeepSeek
-    VERSION = "0.1.1"
+    VERSION = "1.9.0"
   end
 end

--- a/omniai-deepseek.gemspec
+++ b/omniai-deepseek.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai"
+  spec.add_dependency "omniai", "~> 1.9"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
This ensure any future releases of breaking changes for OmniAI do not break existing clients.